### PR TITLE
Use OMI's stable branch for SCXcore build.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "omi"]
 	path = omi
 	url = git@github.com:Microsoft/omi.git
-	branch = master
+	branch = stable
 [submodule "pal"]
 	path = pal
 	url = git@github.com:Microsoft/pal.git
@@ -14,3 +14,7 @@
 	path = opsmgr-kits
 	url = git@github.com:Microsoft/SCXcore-osskits.git
 	branch = master
+[submodule "omi-kits"]
+	path = omi-kits
+	url = git@github.com:Microsoft/omi-kits.git
+       branch = master


### PR DESCRIPTION
OMS will now get OMI through SCX kits.
As OMS currently uses OMI's stable branch for it's build,
we are updating our build to use the stable branch of OMI.

@jeffaco 